### PR TITLE
Treat AI responses without code blocks as JavaScript

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -113,6 +113,17 @@ function InitVue(obj, args = {}) {
 
     }
 
+    // If no code blocks were found, treat the entire message as a code block
+    if (files.length === 0 && message.trim()) {
+        files.push({
+            name: "script.js",
+            content: message,
+            langauge: "javascript",
+            hidden: false
+        });
+        messageWithoutCodeBlocks = ""; // Clear the message since we're using it as code
+    }
+
     return { messageWithoutCodeBlocks, files };
 }
 class SeededRandom {


### PR DESCRIPTION
### **User description**
Modified parseFilesFromMessage() in src/utils.js to treat entire AI response as JavaScript code when no code blocks are detected. This prevents 'empty code' errors when AI provides direct code without markdown formatting.

Changes:
- Added fallback logic to create script.js file with full response content
- Prevents "empty code" errors for direct JavaScript responses


___

### **PR Type**
Enhancement


___

### **Description**
- Treat entire AI response as JavaScript when no code blocks detected

- Prevents "empty code" errors for direct code responses

- Creates fallback script.js file with full message content


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AI Response"] --> B{"Code blocks found?"}
  B -->|Yes| C["Parse code blocks"]
  B -->|No| D["Treat as JavaScript"]
  C --> E["Return files array"]
  D --> F["Create script.js file"]
  F --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.js</strong><dd><code>Add fallback for responses without code blocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils.js

<ul><li>Added fallback logic to handle AI responses without code blocks<br> <li> When no code blocks detected, entire message treated as JavaScript <br>code<br> <li> Creates <code>script.js</code> file with full response content<br> <li> Clears <code>messageWithoutCodeBlocks</code> when using response as code</ul>


</details>


  </td>
  <td><a href="https://github.com/friuns2/SketchbookAI/pull/25/files#diff-3274f1a37032fb0ae4e2823def0007c634e869ae0dfc304ff6a12c36513c3a52">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

